### PR TITLE
feat: Command aliases

### DIFF
--- a/cliffy/commanders/typer.py
+++ b/cliffy/commanders/typer.py
@@ -7,13 +7,21 @@ class TyperCommander(Commander):
     """Generates commands based on the command config"""
 
     def add_base_imports(self):
-        self.cli = f"""## Generated {self.manifest.name} on {datetime.datetime.now()}
-import typer
-import subprocess
-from typing import Optional
-"""
+        self.cli = f"""## Generated {self.manifest.name} on {datetime.datetime.now()}\n"""
+        for imp in self.base_imports:
+            self.cli += imp + "\n"
 
     def add_base_cli(self) -> None:
+        if self.command_aliases:
+            self.cli += f"""BASE_ALIASES = {str(self.command_aliases)}
+class BaseAliasGroup(TyperGroup):
+    def get_command(self, ctx: Any, cmd_name: str) -> Optional[Any]:
+        if cmd_name in BASE_ALIASES:
+            return self.commands.get(BASE_ALIASES[cmd_name])
+
+        return super().get_command(ctx, cmd_name)
+"""
+
         self.cli += """
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 cli = typer.Typer(context_settings=CONTEXT_SETTINGS"""
@@ -22,20 +30,44 @@ cli = typer.Typer(context_settings=CONTEXT_SETTINGS"""
             self.cli += f",{self.parser.to_args(self.manifest.cli_options)}"
         if self.manifest.help:
             self.cli += f', help="""{self.manifest.help}"""'
-
+        if self.command_aliases:
+            self.cli += ", cls=BaseAliasGroup"
         self.cli += f""")
 __version__ = '{self.manifest.version}'
 __cli_name__ = '{self.manifest.name}'
 
+"""
 
+        self.cli += """
 def version_callback(value: bool):
     if value:
-        print(f"{{__cli_name__}}, {{__version__}}")
+        print(f"{__cli_name__}, {__version__}")
         raise typer.Exit()
+"""
 
-
+        if self.aliases_by_commands:
+            self.cli += """
+def aliases_callback(value: bool):
+    if value:
+        print(\"\"\"
+"""
+            for command, alias_list in self.aliases_by_commands.items():
+                self.cli += f"{command}: "
+                self.cli += ", ".join(alias_list)
+                self.cli += "\n"
+            self.cli += """\"\"\")
+        raise typer.Exit()
+"""
+        self.cli += """
 @cli.callback()
-def main(version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)):
+def main("""
+        if self.aliases_by_commands:
+            self.cli += """
+    aliases: Optional[bool] = typer.Option(None, '--aliases', callback=aliases_callback, is_eager=True),"""
+
+        self.cli += """
+    version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)
+):
     pass
 
 """
@@ -48,7 +80,23 @@ def {self.parser.get_command_func_name(command)}({self.parser.parse_args(command
 """
 
     def add_group(self, group: Group) -> None:
-        self.cli += f"""{group.name}_app = typer.Typer()
+        if group.command_aliases:
+            self.cli += f"""
+{group.name.upper()}_ALIASES = {str(group.command_aliases)}
+class {group.name.capitalize()}AliasGroup(TyperGroup):
+    def get_command(self, ctx: Any, cmd_name: str) -> Optional[Any]:
+        if cmd_name in {group.name.upper()}_ALIASES:
+            return self.commands.get({group.name.upper()}_ALIASES[cmd_name])
+
+        return super().get_command(ctx, cmd_name)
+
+"""
+        self.cli += f"{group.name}_app = typer.Typer("
+
+        if group.command_aliases:
+            self.cli += f"cls={group.name.capitalize()}AliasGroup"
+
+        self.cli += f""")
 cli.add_typer({group.name}_app, name="{group.name}", help="{group.help}")
 """
 

--- a/cliffy/manifests/v1.py
+++ b/cliffy/manifests/v1.py
@@ -111,7 +111,7 @@ requires: []
 {cls.get_field_description('vars')}
 vars:
     default_mood: happy
-    debug_mode: "{{ env['DEBUG'] or 'False' }}"
+    debug_mode: "{{{{ env['DEBUG'] or 'False' }}}}"
 
 {cls.get_field_description('imports')}
 imports:

--- a/cliffy/manifests/v1.py
+++ b/cliffy/manifests/v1.py
@@ -45,6 +45,7 @@ class CLIManifest(BaseModel):
         description="A mapping containing the command definitions for the CLI. "
         "Each command should have a unique key- which can be either a group command or nested subcommands. "
         "Nested subcommands are joined by '.' in between each level. "
+        "Aliases for commands can be separated in the key by '|'. "
         "A special (*) wildcard can be used to spread the subcommand to all group-level commands. "
         "The value is the python code to run when the command is called "
         "OR a list of bash commands to run (prefixed with $).",
@@ -139,8 +140,8 @@ args:
 
 {cls.get_field_description('commands')}
 commands:
-    # this is a parent command that will get invoked with: hello world
-    world: 
+    # this is a parent command that will get invoked with: hello world or hello wld
+    world|wld:
         - |
             \"\"\"
             Help text for list

--- a/cliffy/parser.py
+++ b/cliffy/parser.py
@@ -130,8 +130,8 @@ class Parser:
         return parsed_command_args[:-2]
 
     def get_command_func_name(self, command) -> str:
-        """a -> a, a.b -> a_b, a-b -> a_b"""
-        return command.name.replace(".", "_").replace("-", "_")
+        """a -> a, a.b -> a_b, a-b -> a_b, a|b -> a_b"""
+        return command.name.replace(".", "_").replace("-", "_").replace("|", "_")
 
     def get_parsed_command_name(self, command) -> str:
         """a -> a, a.b -> b"""

--- a/examples/db.yaml
+++ b/examples/db.yaml
@@ -13,20 +13,20 @@ imports: |
   console = Console()
 
 commands:
-  create: |
+  create|mk: |
     """Create a new database"""
     console.print(f"Creating database {name}", style="green")
-  delete: |
+  delete|rm: |
     """Delete a database"""
     sure = typer.confirm("Are you really really really sure?")
     if sure:
         console.print(f"Deleting database {name}", style="red")
     else:
         console.print(f"Back to safety!", style="green")
-  list: |
+  list|ls: |
     """List databases"""
     print("Listing all databases")
-  view: |
+  view|v: |
     """View database table"""
     console.print(f"Viewing {table} table for {name} DB")
 

--- a/examples/town.yaml
+++ b/examples/town.yaml
@@ -42,13 +42,13 @@ commands:
   shops.buy: |
     """Buy a shop"""
     print(f"buying shop {name} for ${money}")
-  home.build: |
+  home.build|bu: |
     """Build a home"""
     print(f"building home at {address} for {owner} on land {land}")
-  home.sell: |
+  home.sell|s: |
     """Sell a home"""
     print(f"selling home {address} for {format_money(money)}")
-  home.buy: |
+  home.buy|b: |
     """Buy a home"""
     print(f"buying home {address} for {money}")
     print("test123")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,6 +30,8 @@ CLI_TESTS = {
         {"args": "land build test123 202str", "resp": "building land"},
         {"args": "land sell test123 --money 50", "resp": "selling"},
         {"args": "land list", "resp": "listing land"},
+        {"args": "home build test123 202str", "resp": "building home"},
+        {"args": "home bu test123 202str", "resp": "building home"},
     ],
     "template": [
         {"args": "hello bash", "resp": "hello from bash"},
@@ -43,6 +45,7 @@ CLI_TESTS = {
     ],
     "db": [
         {"args": "list", "resp": "Listing all databases"},
+        {"args": "ls", "resp": "Listing all databases"},
     ],
 }
 


### PR DESCRIPTION
Support command aliases with | 

i.e. the following manifest

```
name: testcli
version: 0.1.0

commands:
   list|ls|l: print("listing")
   stuff.remove|rm|r: print("removing stuff")
```

will print "listing" for `testcli list`, `testcli ls`, and `testcli l` and print "removing stuff" for `testcli stuff remove`, `testcli stuff rm`, and `testcli stuff r`.