### PR TITLE
feat: Command aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	pytest -vv --capture=tee-sys
 
 clean:
-	rm -rf build/ dist/ *.egg-info .*_cache
+	rm -rf build/ dist/ *.egg-info .*_cache test-builds test-manifest-builds
 	find . -name '*.pyc' -type f -exec rm -rf {} +
 	find . -name '__pycache__' -exec rm -rf {} +
 

--- a/cliffy/cli.py
+++ b/cliffy/cli.py
@@ -25,7 +25,14 @@ from .transformer import Transformer
 from .reloader import CLIManifestReloader
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
-ALIASES = {"ls": "list", "add": "load", "reload": "update", "rm": "remove", "rm-all": "remove-all"}
+ALIASES = {
+    "ls": "list",
+    "add": "load",
+    "reload": "update",
+    "rm": "remove",
+    "rm-all": "remove-all",
+    "rmall": "remove-all",
+}
 
 
 class ManifestOrCLI(click.File):
@@ -250,4 +257,5 @@ cli.command("add", hidden=True, epilog="Alias for load")(load)
 cli.command("ls", hidden=True, epilog="Alias for list")(cliffy_list)
 cli.command("rm", hidden=True, epilog="Alias for remove")(remove)
 cli.command("rm-all", hidden=True, epilog="Alias for remove-all")(remove_all)
+cli.command("rmall", hidden=True, epilog="Alias for remove-all")(remove_all)
 cli.command("reload", hidden=True, epilog="Alias for update")(update)

--- a/cliffy/cli.py
+++ b/cliffy/cli.py
@@ -7,7 +7,6 @@ from click.core import Context, Parameter
 from click.types import _is_file_like
 
 from .rich import click, Console, print_rich_table
-from .rich import ClickGroup  # type: ignore
 
 from .builder import build_cli, build_cli_from_manifest, run_cli
 from .helper import (
@@ -29,14 +28,6 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 ALIASES = {"ls": "list", "add": "load", "reload": "update", "rm": "remove", "rm-all": "remove-all"}
 
 
-class AliasedGroup(ClickGroup):
-    def get_command(self, ctx: click.Context, cmd_name: Optional[str]) -> Optional[click.Command]:
-        if cmd_name in ALIASES:
-            return super().get_command(ctx, ALIASES[cmd_name])
-
-        return super().get_command(ctx, cmd_name or "")
-
-
 class ManifestOrCLI(click.File):
     def convert(  # type: ignore[override]
         self, value: Union[str, "os.PathLike[str]", IO[Any]], param: Optional[Parameter], ctx: Optional[Context]
@@ -52,22 +43,21 @@ class ManifestOrCLI(click.File):
         return value
 
 
-def aliases_callback(ctx: Any, param: Any, val: bool):
+def show_aliases_callback(ctx: Any, param: Any, val: bool):
     if val:
-        out("")
+        out("Aliases:")
         for alias, command in ALIASES.items():
-            out(f"{command}: {alias}")
+            out(f"  {alias.ljust(10)} Alias for {command}")
         ctx.exit()
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, cls=AliasedGroup)  # type: ignore[arg-type]
+@click.group(context_settings=CONTEXT_SETTINGS)
 @click.version_option()
-@click.option("--aliases", type=bool, is_flag=True, is_eager=True, callback=aliases_callback)
+@click.option("--aliases", type=bool, is_flag=True, is_eager=True, callback=show_aliases_callback)
 def cli(aliases: bool) -> None:
     pass
 
 
-@cli.command()  # type: ignore[arg-type]
 @click.argument("manifests", type=click.File("rb"), nargs=-1)
 def load(manifests: list[TextIO]) -> None:
     """Load CLI for given manifest(s)"""
@@ -80,7 +70,6 @@ def load(manifests: list[TextIO]) -> None:
         out(f" {T.cli.name} -h")
 
 
-@cli.command()  # type: ignore[arg-type]
 @click.argument("cli_names", type=str, nargs=-1)
 def update(cli_names: list[str]) -> None:
     """Reloads CLI by name"""
@@ -96,7 +85,6 @@ def update(cli_names: list[str]) -> None:
             out_err(f"~ {cli_name} not found")
 
 
-@cli.command()  # type: ignore[arg-type]
 @click.argument("manifest", type=click.File("rb"))
 def render(manifest: TextIO) -> None:
     """Render the CLI manifest generation as code"""
@@ -106,7 +94,6 @@ def render(manifest: TextIO) -> None:
     out(f"# Rendered {T.cli.name} CLI v{T.cli.version} ~", fg="green")
 
 
-@cli.command("run")  # type: ignore[arg-type]
 @click.argument("manifest", type=click.File("rb"))
 @click.argument("cli_args", type=str, nargs=-1)
 def cliffy_run(manifest: TextIO, cli_args: tuple[str]) -> None:
@@ -115,7 +102,6 @@ def cliffy_run(manifest: TextIO, cli_args: tuple[str]) -> None:
     run_cli(T.cli.name, T.cli.code, cli_args)
 
 
-@cli.command()  # type: ignore[arg-type]
 @click.argument("cli_name", type=str, default="cliffy")
 @click.option("--version", "-v", type=str, show_default=True, default="v1", help="Manifest version")
 @click.option("--render", is_flag=True, show_default=True, default=False, help="Render template to terminal directly")
@@ -143,7 +129,6 @@ def init(cli_name: str, version: str, render: bool, raw: bool) -> None:
         out(f"+ {cli_name}.yaml", fg="green")
 
 
-@cli.command("list")  # type: ignore[arg-type]
 def cliffy_list() -> None:
     """List all CLIs loaded"""
     cols = ["Name", "Version", "Age", "Manifest"]
@@ -154,7 +139,6 @@ def cliffy_list() -> None:
     print_rich_table(cols, rows, styles=["cyan", "magenta", "green", "blue"])
 
 
-@cli.command()  # type: ignore[arg-type]
 @click.argument("cli_names", type=str, nargs=-1)
 def remove(cli_names: list[str]) -> None:
     """Remove a loaded CLI by name"""
@@ -167,7 +151,6 @@ def remove(cli_names: list[str]) -> None:
             out_err(f"~ {cli_name} not loaded")
 
 
-@cli.command()  # type: ignore[arg-type]
 def remove_all() -> None:
     """Remove all loaded CLIs"""
     for metadata in get_clis():
@@ -176,7 +159,6 @@ def remove_all() -> None:
         out(f"~ {metadata.cli_name} removed 💥", fg="green")
 
 
-@cli.command()  # type: ignore[arg-type]
 @click.argument("cli_or_manifests", type=ManifestOrCLI(), nargs=-1)
 @click.option("--output-dir", "-o", type=click.Path(file_okay=False, dir_okay=True, writable=True), help="Output dir")
 @click.option(
@@ -215,7 +197,6 @@ def build(cli_or_manifests: list[Union[TextIOWrapper, str]], output_dir: str, py
         out(f"+ {cli_name} built 📦", fg="green")
 
 
-@cli.command()  # type: ignore[arg-type]
 @click.argument("cli_name", type=str)
 def info(cli_name: str):
     """Display CLI info"""
@@ -227,7 +208,6 @@ def info(cli_name: str):
     out(f"{click.style('manifest:', fg='blue')}\n{indent_block(metadata.manifest, spaces=2)}")
 
 
-@cli.command()  # type: ignore[arg-type]
 @click.argument("manifest", type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True))
 @click.option(
     "--run-cli",
@@ -250,3 +230,24 @@ def dev(manifest: str, run_cli: bool, run_cli_args: tuple[str]) -> None:
     """
     out(f"Watching {manifest} for changes\n", fg="magenta")
     CLIManifestReloader.watch(manifest, run_cli, run_cli_args)
+
+
+# register commands
+load_command = cli.command("load")(load)
+build_command = cli.command("build")(build)
+dev_command = cli.command("dev")(dev)
+info_command = cli.command("info")(info)
+init_command = cli.command("init")(init)
+list_command = cli.command("list")(cliffy_list)
+render_command = cli.command("render")(render)
+remove_command = cli.command("remove")(remove)
+remove_all_command = cli.command("remove-all")(remove_all)
+run_command = cli.command("run")(cliffy_run)
+update_command = cli.command("update")(update)
+
+# register aliases
+cli.command("add", hidden=True, epilog="Alias for load")(load)
+cli.command("ls", hidden=True, epilog="Alias for list")(cliffy_list)
+cli.command("rm", hidden=True, epilog="Alias for remove")(remove)
+cli.command("rm-all", hidden=True, epilog="Alias for remove-all")(remove_all)
+cli.command("reload", hidden=True, epilog="Alias for update")(update)

--- a/cliffy/commander.py
+++ b/cliffy/commander.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import DefaultDict, Optional
+from typing import DefaultDict
 
 from pybash.transformer import transform as transform_bash
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .manifests import CommandBlock, Manifest
 from .parser import Parser
@@ -13,6 +13,7 @@ from .parser import Parser
 class Command(BaseModel):
     name: str
     script: CommandBlock
+    aliases: list[str] = Field(default_factory=list)
 
     @classmethod
     def from_greedy_make_lazy(cls, greedy_command: Command, group: str) -> Command:
@@ -42,7 +43,6 @@ class Group(BaseModel):
     name: str
     commands: list[Command]
     help: str = ""
-    command_aliases: Optional[dict[str, str]]
 
 
 class Commander:
@@ -71,8 +71,7 @@ class Commander:
             Command(name=name, script=script) for name, script in self.manifest.commands.items()
         ]
         self.root_commands: list[Command] = [command for command in self.commands if "." not in command.name]
-        self.command_aliases: dict[str, str] = {}
-        self.base_imports: set[str] = {"import typer", "import subprocess", "from typing import Optional, Any"}
+        self.base_imports: set[str] = set()
         self.aliases_by_commands: dict[str, list[str]] = defaultdict(list)
         self.build_groups()
         self.setup_command_aliases()
@@ -80,7 +79,6 @@ class Commander:
     def setup_command_aliases(self) -> None:
         for command in self.commands:
             if "|" in command.name:
-                self.base_imports.add("from typer.core import TyperGroup")
                 aliases = command.name.split("|")
 
                 # skip group command aliases
@@ -89,13 +87,12 @@ class Commander:
 
                 command.name = aliases[0]  # update command.name without the alias part
                 for alias in aliases[1:]:
-                    self.command_aliases[alias] = aliases[0]
+                    command.aliases.append(alias)
                     self.aliases_by_commands[command.name].append(alias)
 
     def build_groups(self) -> None:
         groups: DefaultDict[str, list[Command]] = defaultdict(list)
         group_help_dict: dict[str, str] = {}
-        group_command_aliases: DefaultDict[str, dict[str, str]] = defaultdict(dict)
 
         for command in self.commands:
             # Check for greedy commands- evaluate them at the end
@@ -107,12 +104,10 @@ class Commander:
                 group_name = command.name.split(".")[:-1][-1]
 
                 if "|" in command.name:
-                    self.base_imports.add("from typer.core import TyperGroup")
                     command_aliases = command.name.rsplit(".", 1)[1].split("|")
-                    root_alias = command_aliases[0]
                     command_name_sub_alias = command.name.split("|", 1)[0]
                     for alias in command_aliases[1:]:
-                        group_command_aliases[group_name][alias] = root_alias
+                        command.aliases.append(alias)
                         self.aliases_by_commands[command_name_sub_alias].append(alias)
 
                     command.name = command_name_sub_alias
@@ -130,7 +125,6 @@ class Commander:
                 name=group_name,
                 commands=commands,
                 help=group_help_dict.get(group_name, ""),
-                command_aliases=group_command_aliases.get(group_name),
             )
 
     def generate_cli(self) -> None:

--- a/cliffy/commanders/typer.py
+++ b/cliffy/commanders/typer.py
@@ -45,7 +45,7 @@ def aliases_callback(value: bool):
     if value:
         print(\"\"\""""
             max_command_length = max(len(x) for x in self.aliases_by_commands.keys())
-            self.cli +=  f"""
+            self.cli += f"""
 {"Command".ljust(max_command_length + 7)}Aliases
 {"--------".ljust(max_command_length + 7)}--------
 """

--- a/cliffy/commanders/typer.py
+++ b/cliffy/commanders/typer.py
@@ -43,10 +43,14 @@ def version_callback(value: bool):
             self.cli += """
 def aliases_callback(value: bool):
     if value:
-        print(\"\"\"
+        print(\"\"\""""
+            max_command_length = max(len(x) for x in self.aliases_by_commands.keys())
+            self.cli +=  f"""
+{"Command".ljust(max_command_length + 7)}Aliases
+{"--------".ljust(max_command_length + 7)}--------
 """
             for command, alias_list in self.aliases_by_commands.items():
-                self.cli += f"{command}: "
+                self.cli += f"{command.ljust(max_command_length + 7)}"
                 self.cli += ", ".join(alias_list)
                 self.cli += "\n"
             self.cli += """\"\"\")

--- a/cliffy/commanders/typer.py
+++ b/cliffy/commanders/typer.py
@@ -7,13 +7,21 @@ class TyperCommander(Commander):
     """Generates commands based on the command config"""
 
     def add_base_imports(self):
-        self.cli = f"""## Generated {self.manifest.name} on {datetime.datetime.now()}
-import typer
-import subprocess
-from typing import Optional
-"""
+        self.cli = f"""## Generated {self.manifest.name} on {datetime.datetime.now()}\n"""
+        for imp in self.base_imports:
+            self.cli += imp + "\n"
 
     def add_base_cli(self) -> None:
+        if self.command_aliases:
+            self.cli += f"""BASE_ALIASES = {str(self.command_aliases)}
+class BaseAliasGroup(TyperGroup):
+    def get_command(self, ctx: Any, cmd_name: str) -> Optional[Any]:
+        if cmd_name in BASE_ALIASES:
+            return self.commands.get(BASE_ALIASES[cmd_name])
+
+        return super().get_command(ctx, cmd_name)
+"""
+
         self.cli += """
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 cli = typer.Typer(context_settings=CONTEXT_SETTINGS"""
@@ -22,20 +30,44 @@ cli = typer.Typer(context_settings=CONTEXT_SETTINGS"""
             self.cli += f",{self.parser.to_args(self.manifest.cli_options)}"
         if self.manifest.help:
             self.cli += f', help="""{self.manifest.help}"""'
-
+        if self.command_aliases:
+            self.cli += ", cls=BaseAliasGroup"
         self.cli += f""")
 __version__ = '{self.manifest.version}'
 __cli_name__ = '{self.manifest.name}'
 
+"""
 
+        self.cli += """
 def version_callback(value: bool):
     if value:
-        print(f"{{__cli_name__}}, {{__version__}}")
+        print(f"{__cli_name__}, {__version__}")
         raise typer.Exit()
+"""
 
-
+        if self.aliases_by_commands:
+            self.cli += """
+def aliases_callback(value: bool):
+    if value:
+        print(\"\"\"
+"""
+            for command, alias_list in self.aliases_by_commands.items():
+                self.cli += f"{command}: "
+                self.cli += ", ".join(alias_list)
+                self.cli += "\n"
+            self.cli += """\"\"\")
+        raise typer.Exit()
+"""
+        self.cli += """
 @cli.callback()
-def main(version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)):
+def main("""
+        if self.aliases_by_commands:
+            self.cli += """
+    aliases: Optional[bool] = typer.Option(None, '--aliases', callback=aliases_callback, is_eager=True),"""
+
+        self.cli += """
+    version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)
+):
     pass
 
 """
@@ -48,7 +80,23 @@ def {self.parser.get_command_func_name(command)}({self.parser.parse_args(command
 """
 
     def add_group(self, group: Group) -> None:
-        self.cli += f"""{group.name}_app = typer.Typer()
+        if group.command_aliases:
+            self.cli += f"""
+{group.name.upper()}_ALIASES = {str(group.command_aliases)}
+class {group.name.capitalize()}AliasGroup(TyperGroup):
+    def get_command(self, ctx: Any, cmd_name: str) -> Optional[Any]:
+        if cmd_name in {group.name.upper()}_ALIASES:
+            return self.commands.get({group.name.upper()}_ALIASES[cmd_name])
+
+        return super().get_command(ctx, cmd_name)
+
+"""
+        self.cli += f"{group.name}_app = typer.Typer("
+
+        if group.command_aliases:
+            self.cli += f"cls={group.name.capitalize()}AliasGroup"
+
+        self.cli += f""")
 cli.add_typer({group.name}_app, name="{group.name}", help="{group.help}")
 """
 

--- a/cliffy/manifests/v1.py
+++ b/cliffy/manifests/v1.py
@@ -111,7 +111,7 @@ requires: []
 {cls.get_field_description('vars')}
 vars:
     default_mood: happy
-    debug_mode: "{{ env['DEBUG'] or 'False' }}"
+    debug_mode: "{{{{ env['DEBUG'] or 'False' }}}}"
 
 {cls.get_field_description('imports')}
 imports:

--- a/cliffy/manifests/v1.py
+++ b/cliffy/manifests/v1.py
@@ -45,6 +45,7 @@ class CLIManifest(BaseModel):
         description="A mapping containing the command definitions for the CLI. "
         "Each command should have a unique key- which can be either a group command or nested subcommands. "
         "Nested subcommands are joined by '.' in between each level. "
+        "Aliases for commands can be separated in the key by '|'. "
         "A special (*) wildcard can be used to spread the subcommand to all group-level commands. "
         "The value is the python code to run when the command is called "
         "OR a list of bash commands to run (prefixed with $).",
@@ -139,8 +140,8 @@ args:
 
 {cls.get_field_description('commands')}
 commands:
-    # this is a parent command that will get invoked with: hello world
-    world: 
+    # this is a parent command that will get invoked with: hello world or hello wld
+    world|wld:
         - |
             \"\"\"
             Help text for list

--- a/cliffy/parser.py
+++ b/cliffy/parser.py
@@ -130,8 +130,8 @@ class Parser:
         return parsed_command_args[:-2]
 
     def get_command_func_name(self, command) -> str:
-        """a -> a, a.b -> a_b, a-b -> a_b"""
-        return command.name.replace(".", "_").replace("-", "_")
+        """a -> a, a.b -> a_b, a-b -> a_b, a|b -> a_b"""
+        return command.name.replace(".", "_").replace("-", "_").replace("|", "_")
 
     def get_parsed_command_name(self, command) -> str:
         """a -> a, a.b -> b"""

--- a/examples/db.yaml
+++ b/examples/db.yaml
@@ -13,20 +13,20 @@ imports: |
   console = Console()
 
 commands:
-  create: |
+  create|mk: |
     """Create a new database"""
     console.print(f"Creating database {name}", style="green")
-  delete: |
+  delete|rm: |
     """Delete a database"""
     sure = typer.confirm("Are you really really really sure?")
     if sure:
         console.print(f"Deleting database {name}", style="red")
     else:
         console.print(f"Back to safety!", style="green")
-  list: |
+  list|ls: |
     """List databases"""
     print("Listing all databases")
-  view: |
+  view|v: |
     """View database table"""
     console.print(f"Viewing {table} table for {name} DB")
 

--- a/examples/generated/db.py
+++ b/examples/generated/db.py
@@ -1,14 +1,22 @@
-## Generated db on 2024-08-02 14:08:54.018361
+## Generated db on 2024-08-06 21:09:20.229514
+from typing import Optional, Any
 import typer
+from typer.core import TyperGroup
 import subprocess
-from typing import Optional
 from rich.console import Console
 console = Console()
 
 
+BASE_ALIASES = {'mk': 'create', 'rm': 'delete', 'ls': 'list', 'v': 'view'}
+class BaseAliasGroup(TyperGroup):
+    def get_command(self, ctx: Any, cmd_name: str) -> Optional[Any]:
+        if cmd_name in BASE_ALIASES:
+            return self.commands.get(BASE_ALIASES[cmd_name])
+
+        return super().get_command(ctx, cmd_name)
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
-cli = typer.Typer(context_settings=CONTEXT_SETTINGS, add_completion=False, help="""Database CLI""")
+cli = typer.Typer(context_settings=CONTEXT_SETTINGS, add_completion=False, help="""Database CLI""", cls=BaseAliasGroup)
 __version__ = '0.1.0'
 __cli_name__ = 'db'
 
@@ -18,9 +26,21 @@ def version_callback(value: bool):
         print(f"{__cli_name__}, {__version__}")
         raise typer.Exit()
 
+def aliases_callback(value: bool):
+    if value:
+        print("""
+create: mk
+delete: rm
+list: ls
+view: v
+""")
+        raise typer.Exit()
 
 @cli.callback()
-def main(version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)):
+def main(
+    aliases: Optional[bool] = typer.Option(None, '--aliases', callback=aliases_callback, is_eager=True),
+    version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)
+):
     pass
 
 

--- a/examples/generated/environ.py
+++ b/examples/generated/environ.py
@@ -1,7 +1,7 @@
-## Generated environ on 2024-08-02 14:08:54.024887
+## Generated environ on 2024-08-06 21:09:20.234970
+from typing import Optional, Any
 import typer
 import subprocess
-from typing import Optional
 import os
 
 default_env_var = 'hello'
@@ -18,9 +18,10 @@ def version_callback(value: bool):
         print(f"{__cli_name__}, {__version__}")
         raise typer.Exit()
 
-
 @cli.callback()
-def main(version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)):
+def main(
+    version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)
+):
     pass
 
 

--- a/examples/generated/hello.py
+++ b/examples/generated/hello.py
@@ -1,7 +1,7 @@
-## Generated hello on 2024-08-02 14:08:54.027610
+## Generated hello on 2024-08-06 21:09:20.239310
+from typing import Optional, Any
 import typer
 import subprocess
-from typing import Optional
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 cli = typer.Typer(context_settings=CONTEXT_SETTINGS, help="""Hello world!""")
@@ -14,9 +14,10 @@ def version_callback(value: bool):
         print(f"{__cli_name__}, {__version__}")
         raise typer.Exit()
 
-
 @cli.callback()
-def main(version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)):
+def main(
+    version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)
+):
     pass
 
 

--- a/examples/generated/penv.py
+++ b/examples/generated/penv.py
@@ -1,7 +1,7 @@
-## Generated penv on 2024-08-02 14:08:54.032251
+## Generated penv on 2024-08-06 21:09:20.243667
+from typing import Optional, Any
 import typer
 import subprocess
-from typing import Optional
 import os
 from pathlib import Path
 from shutil import rmtree
@@ -24,9 +24,10 @@ def version_callback(value: bool):
         print(f"{__cli_name__}, {__version__}")
         raise typer.Exit()
 
-
 @cli.callback()
-def main(version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)):
+def main(
+    version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)
+):
     pass
 
 def get_venv_path(name: str) -> str:

--- a/examples/generated/pydev.py
+++ b/examples/generated/pydev.py
@@ -1,7 +1,7 @@
-## Generated pydev on 2024-08-02 14:08:54.038822
+## Generated pydev on 2024-08-06 21:09:20.248496
+from typing import Optional, Any
 import typer
 import subprocess
-from typing import Optional
 import sys
 
 
@@ -17,9 +17,10 @@ def version_callback(value: bool):
         print(f"{__cli_name__}, {__version__}")
         raise typer.Exit()
 
-
 @cli.callback()
-def main(version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)):
+def main(
+    version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)
+):
     pass
 
 def run_cmd(cmd: str):

--- a/examples/generated/requires.py
+++ b/examples/generated/requires.py
@@ -1,7 +1,7 @@
-## Generated requires on 2024-08-02 14:08:54.271747
+## Generated requires on 2024-08-06 21:09:20.457028
+from typing import Optional, Any
 import typer
 import subprocess
-from typing import Optional
 import six
 
 
@@ -16,9 +16,10 @@ def version_callback(value: bool):
         print(f"{__cli_name__}, {__version__}")
         raise typer.Exit()
 
-
 @cli.callback()
-def main(version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)):
+def main(
+    version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)
+):
     pass
 
 

--- a/examples/generated/template.py
+++ b/examples/generated/template.py
@@ -1,7 +1,7 @@
-## Generated template on 2024-08-02 14:08:54.276078
+## Generated template on 2024-08-06 21:09:20.460271
+from typing import Optional, Any
 import typer
 import subprocess
-from typing import Optional
 GLOBAL_VAR = 'hello'
 
 
@@ -16,9 +16,10 @@ def version_callback(value: bool):
         print(f"{__cli_name__}, {__version__}")
         raise typer.Exit()
 
-
 @cli.callback()
-def main(version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)):
+def main(
+    version: Optional[bool] = typer.Option(None, '--version', callback=version_callback, is_eager=True)
+):
     pass
 
 

--- a/examples/town.yaml
+++ b/examples/town.yaml
@@ -42,13 +42,13 @@ commands:
   shops.buy: |
     """Buy a shop"""
     print(f"buying shop {name} for ${money}")
-  home.build: |
+  home.build|bu: |
     """Build a home"""
     print(f"building home at {address} for {owner} on land {land}")
-  home.sell: |
+  home.sell|s: |
     """Sell a home"""
     print(f"selling home {address} for {format_money(money)}")
-  home.buy: |
+  home.buy|b: |
     """Buy a home"""
     print(f"buying home {address} for {money}")
     print("test123")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cliffy"
-version = "0.3.6"
+version = "0.3.7"
 description = "$ cli load from.yaml"
 authors = ["Jay <jay.github0@gmail.com>"]
 repository = "https://github.com/jaykv/cliffy"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import re
 
 from click.testing import CliRunner
 
-from cliffy.cli import cli, cliffy_run, init, render
+from cliffy.cli import cli, run_command, init_command, render_command
 from cliffy.homer import get_metadata
 
 ANSI_RE = re.compile(r"(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]")
@@ -27,14 +27,14 @@ def test_cli_version():
 
 def test_cli_init():
     runner = CliRunner()
-    result = runner.invoke(init, ["hello", "--render"])
+    result = runner.invoke(init_command, ["hello", "--render"])
     assert result.exit_code == 0
     assert "name: hello" in escape_ansi(result.output)
 
 
 def test_cli_render():
     runner = CliRunner()
-    result = runner.invoke(render, ["examples/town.yaml"])
+    result = runner.invoke(render_command, ["examples/town.yaml"])
     assert result.exit_code == 0
     assert "cli = typer.Typer" in escape_ansi(result.output)
     assert get_metadata("town") is None
@@ -42,7 +42,7 @@ def test_cli_render():
 
 def test_cli_run():
     runner = CliRunner()
-    result = runner.invoke(cliffy_run, ["examples/hello.yaml", "--", "-h"])
+    result = runner.invoke(run_command, ["examples/hello.yaml", "--", "-h"])
     assert result.exit_code == 0
     assert "Hello world!" in escape_ansi(result.output)
     assert get_metadata("hello") is None

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -32,6 +32,7 @@ CLI_TESTS = {
         {"args": "land list", "resp": "listing land"},
         {"args": "home build test123 202str", "resp": "building home"},
         {"args": "home bu test123 202str", "resp": "building home"},
+        {"args": "home s test123", "resp": "selling home"},
     ],
     "template": [
         {"args": "hello bash", "resp": "hello from bash"},

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,6 +30,8 @@ CLI_TESTS = {
         {"args": "land build test123 202str", "resp": "building land"},
         {"args": "land sell test123 --money 50", "resp": "selling"},
         {"args": "land list", "resp": "listing land"},
+        {"args": "home build test123 202str", "resp": "building home"},
+        {"args": "home bu test123 202str", "resp": "building home"},
     ],
     "template": [
         {"args": "hello bash", "resp": "hello from bash"},
@@ -43,6 +45,7 @@ CLI_TESTS = {
     ],
     "db": [
         {"args": "list", "resp": "Listing all databases"},
+        {"args": "ls", "resp": "Listing all databases"},
     ],
 }
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -31,6 +31,8 @@ CLI_TESTS = {
         {"args": "land sell test123 --money 50", "resp": "selling"},
         {"args": "land list", "resp": "listing land"},
         {"args": "home build test123 202str", "resp": "building home"},
+        {"args": "home build invalidalias 202str", "resp": "Error: Invalid alias"},
+        {"args": "home invalidcommand test123 202str", "resp": "Error: Invalid command"},
         {"args": "home bu test123 202str", "resp": "building home"},
         {"args": "home s test123", "resp": "selling home"},
     ],

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -47,6 +47,8 @@ CLI_TESTS = {
     "db": [
         {"args": "list", "resp": "Listing all databases"},
         {"args": "ls", "resp": "Listing all databases"},
+        {"args": "mk", "resp": "Creating database"},
+        {"args": "rm", "resp": "Deleting database"},
     ],
 }
 


### PR DESCRIPTION
Support command aliases with | 

i.e. the following manifest

```
name: testcli
version: 0.1.0

commands:
   list|ls|l: print("listing")
   stuff.remove|rm|r: print("removing stuff")
```

will print "listing" for `testcli list`, `testcli ls`, and `testcli l` and print "removing stuff" for `testcli stuff remove`, `testcli stuff rm`, and `testcli stuff r`.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add support for command aliases in CLI commands, allowing multiple names for a single command using the '|' separator. Enhance CLI generation and add a callback to display aliases. Update documentation and add tests for the new functionality.

New Features:
- Introduce support for command aliases using the '|' separator in command definitions, allowing multiple aliases for a single command.

Enhancements:
- Add a callback to display all command aliases when the '--aliases' option is used.
- Update CLI generation to include alias handling in both base and group commands.

Documentation:
- Update CLI manifest documentation to include information on defining command aliases.

Tests:
- Add tests to verify the functionality of command aliases in various CLI commands.

<!-- Generated by sourcery-ai[bot]: end summary -->