### PR TITLE
feat: cli tester

### DIFF
--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -26,9 +26,9 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Poetry
@@ -42,6 +42,8 @@ jobs:
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.extras }}
+    - name: Set poetry python version
+      run: poetry env use ${pythonLocation}/bin/python
     - name: Install dependencies
       run: poetry install --no-interaction --no-root
       if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.extras == false }}

--- a/cliffy/builder.py
+++ b/cliffy/builder.py
@@ -1,18 +1,16 @@
 from io import TextIOWrapper
 import os
 import sys
-from importlib import import_module
 from pathlib import Path
 from shutil import copy
 from tempfile import NamedTemporaryFile, TemporaryDirectory
-from types import ModuleType
 from typing import Optional
 
 from click.testing import CliRunner, Result
 from shiv import cli as shiv_cli
 from shiv import pip
 
-from cliffy.helper import TEMP_FILES, delete_temp_files
+from cliffy.helper import TEMP_FILES, delete_temp_files, import_module_from_path
 
 from cliffy.transformer import Transformer
 
@@ -60,12 +58,6 @@ def build_cli(
             shiv_cli.main,  # type: ignore
             ["--site-packages", tdist, "--compressed", "-e", f"{cli_name}.cli", "-o", output_file, "-p", interpreter],
         )
-
-
-def import_module_from_path(filepath: str) -> ModuleType:
-    module_path, module_filename = os.path.split(filepath)
-    sys.path.append(module_path)
-    return import_module(module_filename[:-3])
 
 
 def run_cli(cli_name: str, script_code: str, args: tuple) -> None:

--- a/cliffy/helper.py
+++ b/cliffy/helper.py
@@ -13,6 +13,8 @@ from typing import Any, NoReturn, Optional
 from click import secho
 from packaging import version
 from pydantic import BaseModel
+from types import ModuleType
+from importlib import import_module
 
 
 CLIFFY_CLI_DIR = files("cliffy").joinpath("clis")
@@ -47,6 +49,12 @@ def write_to_file(path: str, text: str, executable: bool = False) -> None:
 
     if executable:
         make_executable(path)
+
+
+def import_module_from_path(filepath: str) -> ModuleType:
+    module_path, module_filename = os.path.split(filepath)
+    sys.path.append(module_path)
+    return import_module(module_filename[:-3])
 
 
 def make_executable(path: str) -> None:

--- a/cliffy/helper.py
+++ b/cliffy/helper.py
@@ -56,14 +56,14 @@ def import_module_from_path(filepath: str) -> ModuleType:
         path = Path(filepath)
         module_name = path.stem
         spec = spec_from_file_location(module_name, path)
-        if spec and spec.loader:
-            module = module_from_spec(spec)
-            spec.loader.exec_module(module)
-            return module
-        else:
-            raise ImportError(f"Could not load module from {path}")
+        if not spec or not spec.loader:
+            raise ImportError(f"Could not load module from {filepath}")
+
+        module = module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
     except Exception as e:
-        raise ImportError(f"Failed to import module from {path}: {e}")
+        raise ImportError(f"Failed to import module from {filepath}: {e}")
 
 
 def make_executable(path: str) -> None:

--- a/cliffy/manifests/v1.py
+++ b/cliffy/manifests/v1.py
@@ -77,6 +77,7 @@ class CLIManifest(BaseModel):
         {},
         description="A mapping for any additional options that can be used to customize the behavior of the CLI.",
     )
+    tests: dict[str, str] = Field({}, description="A mapping of command with args to its test script.")
 
     @classmethod
     def get_field_description(cls, field_name: str, as_comment: bool = True) -> str:
@@ -208,6 +209,7 @@ class IncludeManifest(BaseModel):
     functions: list[str] = []
     types: dict[str, str] = {}
     cli_options: dict[str, str] = {}
+    tests: dict[str, str] = {}
 
 
 class CLIMetadata(BaseModel):

--- a/cliffy/reloader.py
+++ b/cliffy/reloader.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import threading
 
 
-class CLIManifestReloader(FileSystemEventHandler):
+class Reloader(FileSystemEventHandler):
     def __init__(self, manifest_path: str, run_cli: bool, run_cli_args: tuple[str]) -> None:
         self.manifest_path = manifest_path
         self.run_cli = run_cli

--- a/cliffy/tester.py
+++ b/cliffy/tester.py
@@ -1,0 +1,40 @@
+from typing import Generator
+from click.testing import Result
+from typer.testing import CliRunner
+from cliffy.commander import Command
+from cliffy.parser import Parser
+from cliffy.transformer import Transformer
+from cliffy.helper import import_module_from_path, delete_temp_files, TEMP_FILES
+from tempfile import NamedTemporaryFile
+import inspect
+
+
+class Tester:
+    def __init__(self, manifest_path: str) -> None:
+        with open(manifest_path, "r") as manifest_io:
+            self.T = Transformer(manifest_io)
+
+        with NamedTemporaryFile(mode="w", prefix=f"{self.T.cli.name}_test_", suffix=".py", delete=False) as runner_file:
+            runner_file.write(self.T.cli.code)
+            runner_file.flush()
+            self.module = import_module_from_path(runner_file.name)
+            TEMP_FILES.append(runner_file)
+
+        self.module_funcs = inspect.getmembers(self.module, inspect.isfunction)
+        delete_temp_files()
+
+        self.runner = CliRunner()
+        self.parser = Parser(self.T.manifest)
+
+    def invoke_test(self, command: str, script: str) -> Generator[Result, None, None]:
+        result = self.runner.invoke(self.module.cli, command)
+        yield result
+        code = compile(script, f"test_{self.T.cli.name}.py", "exec")
+        exec(code, {}, {"result": result, "result_text": result.output.strip()})
+
+    def is_valid_command(self, command: str) -> bool:
+        command_name = command.split(" ")[0]
+        cmd = Command(name=command_name, script="")
+        command_func_name = self.parser.get_command_func_name(cmd)
+        matching_command_func = [func for fname, func in self.module_funcs if fname == command_func_name]
+        return bool(matching_command_func)

--- a/cliffy/transformer.py
+++ b/cliffy/transformer.py
@@ -24,7 +24,6 @@ class Transformer:
         *,
         as_include: bool = False,
         validate_requires: bool = True,
-        add_command_name_mapping: bool = False,
     ) -> None:
         self.manifest_io = manifest_io
         self.command_config = self.load_manifest(manifest_io)

--- a/cliffy/transformer.py
+++ b/cliffy/transformer.py
@@ -18,7 +18,14 @@ class Transformer:
 
     __slots__ = ("manifest_io", "command_config", "manifest_version", "includes_config", "manifest", "cli")
 
-    def __init__(self, manifest_io: TextIO, *, as_include: bool = False, validate_requires: bool = True) -> None:
+    def __init__(
+        self,
+        manifest_io: TextIO,
+        *,
+        as_include: bool = False,
+        validate_requires: bool = True,
+        add_command_name_mapping: bool = False,
+    ) -> None:
         self.manifest_io = manifest_io
         self.command_config = self.load_manifest(manifest_io)
         self.manifest_version = self.command_config.pop("manifestVersion", "v1")

--- a/examples/generated/db.py
+++ b/examples/generated/db.py
@@ -1,4 +1,4 @@
-## Generated db on 2024-08-07 10:34:35.556438
+## Generated db on 2024-08-25 23:31:48.012819
 import typer
 import subprocess
 from typing import Optional, Any

--- a/examples/generated/environ.py
+++ b/examples/generated/environ.py
@@ -1,4 +1,4 @@
-## Generated environ on 2024-08-07 10:34:35.562029
+## Generated environ on 2024-08-25 23:31:48.018345
 import typer
 import subprocess
 from typing import Optional, Any

--- a/examples/generated/hello.py
+++ b/examples/generated/hello.py
@@ -1,4 +1,4 @@
-## Generated hello on 2024-08-07 10:34:35.566032
+## Generated hello on 2024-08-25 23:31:48.022732
 import typer
 import subprocess
 from typing import Optional, Any

--- a/examples/generated/penv.py
+++ b/examples/generated/penv.py
@@ -1,4 +1,4 @@
-## Generated penv on 2024-08-07 10:34:35.569851
+## Generated penv on 2024-08-25 23:31:48.026516
 import typer
 import subprocess
 from typing import Optional, Any

--- a/examples/generated/pydev.py
+++ b/examples/generated/pydev.py
@@ -1,4 +1,4 @@
-## Generated pydev on 2024-08-07 10:34:35.574671
+## Generated pydev on 2024-08-25 23:31:48.031791
 import typer
 import subprocess
 from typing import Optional, Any

--- a/examples/generated/requires.py
+++ b/examples/generated/requires.py
@@ -1,4 +1,4 @@
-## Generated requires on 2024-08-07 10:34:35.763264
+## Generated requires on 2024-08-25 23:31:48.327128
 import typer
 import subprocess
 from typing import Optional, Any

--- a/examples/generated/template.py
+++ b/examples/generated/template.py
@@ -1,4 +1,4 @@
-## Generated template on 2024-08-07 10:34:35.766497
+## Generated template on 2024-08-25 23:31:48.330347
 import typer
 import subprocess
 from typing import Optional, Any

--- a/examples/generated/town.py
+++ b/examples/generated/town.py
@@ -1,4 +1,4 @@
-## Generated town on 2024-08-07 10:34:35.773337
+## Generated town on 2024-08-25 23:31:48.337317
 import typer
 import subprocess
 from typing import Optional, Any

--- a/examples/hello.yaml
+++ b/examples/hello.yaml
@@ -5,3 +5,7 @@ help: Hello world!
 commands:
   bash: $echo "hello from bash"
   python: print("hello from python")
+
+tests:
+  bash: assert result.exit_code == 0
+  python: assert result.output == "hello from python\n"


### PR DESCRIPTION
* New tests section added in manifest
* New command to run CLIs tests with `cli test <manifest path>`

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new CLI command `test` to execute tests defined in a manifest, enhance the manifest schema to include a `tests` section, and introduce a `Tester` class to support CLI testing. Refactor the `CLIManifestReloader` to `Reloader` for improved code clarity.

New Features:
- Introduce a new CLI command `test` to run tests defined in a manifest file, allowing users to execute and validate CLI commands through specified test scripts.

Enhancements:
- Add a `tests` section to the CLI manifest schema to define command tests, enabling structured testing of CLI commands.
- Refactor the `CLIManifestReloader` class to `Reloader` for a more generic implementation.

Tests:
- Implement a new `Tester` class to facilitate the execution of CLI tests, including methods to invoke tests and validate command execution.

<!-- Generated by sourcery-ai[bot]: end summary -->